### PR TITLE
Fix: skip messages with no body

### DIFF
--- a/common/responses.js
+++ b/common/responses.js
@@ -137,6 +137,7 @@ module.exports = class Responses {
 
     message.parts.forEach((part) => {
       if (part.mime_type.indexOf(MIME_TYPES.response) === 0) {
+        if (!part.body) return null
         responseType = 'response-message'
         messagePart = part
       }


### PR DESCRIPTION
It's possible to receive a message response type with no `body`. That usually means we are dealing with external content. 